### PR TITLE
Fix for issue Shift Control C does nothing #1

### DIFF
--- a/Sass Colors.sketchplugin/Contents/Sketch/sketch-sass-colors.cocoascript
+++ b/Sass Colors.sketchplugin/Contents/Sketch/sketch-sass-colors.cocoascript
@@ -38,7 +38,7 @@ var SketchSassColorsShowColors = function(context) {
 
     // Format a message using the colors.
     if (colors) {
-      var defaultSassVariablesStrings = SketchSassColors.getSassVariablesString();
+      var defaultSassVariablesStrings = SketchConfig.get(key);
       var variables = SketchSassColors.getSassVariablesFromString(defaultSassVariablesStrings);
       message = SketchSassColors.getMessageForColorsWithVariables(colors, variables);
     }


### PR DESCRIPTION
Replacing method call SketchSassColors.getSassVariablesString() for var defaultSassVariablesStrings = SketchConfig.get(key);